### PR TITLE
fix: make sure the new password isn't the same as the old one while resetting password

### DIFF
--- a/backend/routes/auth.ts
+++ b/backend/routes/auth.ts
@@ -204,6 +204,10 @@ router.post('/change-password', async (req: Request, res: Response) => {
             res.status(400).json({ message: 'Old password and new password are required' });
             return;
         }
+        if (old_password === new_password) {
+            res.status(400).json({ message: 'New password cannot be the same as the old password' });
+            return;
+        }
         const user = await db
             .selectFrom('Profile')
             .selectAll()

--- a/frontend/src/components/Setting.tsx
+++ b/frontend/src/components/Setting.tsx
@@ -7,6 +7,10 @@ async function passwordReset(oldPassword: React.RefObject<HTMLInputElement | nul
         alert('需填入舊密碼與新密碼！');
         return;
     }
+    if (oldPassword.current.value === newPassword.current.value) {
+        alert('新密碼與舊密碼相同！');
+        return;
+    }
     return fetch(basicURL + 'api/auth/change-password', {
         method: 'POST',
         headers: {


### PR DESCRIPTION
This pull request adds a new validation to prevent users from setting their new password to be the same as their old password. 
This pull request fixes #72 
The validation is implemented on both the backend and frontend to improve user experience and security.

**Password Change Validation:**

* Backend (`backend/routes/auth.ts`): Added a check in the `/change-password` route to return an error if the new password is the same as the old password.
* Frontend (`frontend/src/components/Setting.tsx`): Added a check in the `passwordReset` function to alert the user if the new password matches the old password, preventing the request from being sent.